### PR TITLE
Vehicle spawns with %100 fuel

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -72,6 +72,8 @@ function StartDriveTest(type)
 
 		local playerPed   = PlayerPedId()
 		TaskWarpPedIntoVehicle(playerPed, vehicle, -1)
+  		Citizen.Wait(1)
+		exports["LegacyFuel"]:SetFuel(vehicle, 100)
 	end)
 
 	TriggerServerEvent('esx_dmvschool:pay', Config.Prices[type])


### PR DESCRIPTION
On DMV School Vehicles spawn with random fuel level creates problem for players.
This little fix from Legacy fuel solve that problem.